### PR TITLE
Fix generic typing in doubly linked list

### DIFF
--- a/data_structures/linked_list/doubly_linked_list_two.py
+++ b/data_structures/linked_list/doubly_linked_list_two.py
@@ -10,13 +10,13 @@
 """
 
 from dataclasses import dataclass
-from typing import Self, TypeVar
+from typing import Self, TypeVar, Generic
 
 DataType = TypeVar("DataType")
 
 
 @dataclass
-class Node[DataType]:
+class Node(Generic[DataType]):
     data: DataType
     previous: Self | None = None
     next: Self | None = None


### PR DESCRIPTION
## Summary
- make `Node` class in `doubly_linked_list_two` a generic type

## Testing
- `pytest data_structures/linked_list/doubly_linked_list_two.py -q`
- `pytest data_structures -q`

------
https://chatgpt.com/codex/tasks/task_e_6865bae13e088322943cbeb0a4b2029d